### PR TITLE
Wire frasermolyneux-copilot MCP server (v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,3 +23,9 @@
 
 ## Extending
 - Add new endpoints by deriving from `BaseApi<InvisionApiClientOptions>`, adding an interface under `MX.InvisionCommunity.Api.Abstractions/Interfaces/`, registering via `AddTypedApiClient<>()` in `ServiceCollectionExtensions`, and updating `InvisionApiClient` to surface the client. Add corresponding fake and factory methods in the testing package.
+
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,19 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: |
+          npm ci
+          npm run build
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 
 ## Security
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+This repo is wired to the `frasermolyneux-copilot` MCP server (shared catalog from [`frasermolyneux/.github-copilot`](https://github.com/frasermolyneux/.github-copilot), pinned to tag `v0.1.0`). The Copilot coding-agent config lives in [`.github/copilot/mcp_config.json`](.github/copilot/mcp_config.json) and the runner build is handled by [`.github/workflows/copilot-setup-steps.yml`](.github/workflows/copilot-setup-steps.yml). See `.github-copilot/mcp-server/README.md` (in the shared repo) for the tool surface, content-root resolution, and per-client wire-up snippets (VS Code, Claude Desktop, Copilot CLI).


### PR DESCRIPTION
## Why

Wires the shared org Copilot catalog MCP server into this repo so that MCP-capable agents (VS Code Copilot Chat, the GitHub Copilot coding agent, Copilot CLI, Claude Desktop) can call `frasermolyneux-copilot`'s `list_instructions` / `get_instruction` / `search_instructions` (plus the `_prompts` and `_agents` equivalents) for live org conventions, instead of relying on stale assumptions or only the file-load model.

This matches the template already merged into `portal-core` and pins the shared-config checkout to tag `v0.1.0` of `frasermolyneux/.github-copilot` for build stability.

## What changed

- **`.github/workflows/copilot-setup-steps.yml`** - pin shared-copilot checkout to `ref: refs/tags/v0.1.0`, add `actions/setup-node@v6` (Node 20.x), build the MCP server with `npm ci && npm run build` in `.github-copilot/mcp-server`. Existing `.NET` setup preserved.
- **`.github/copilot/mcp_config.json`** (new) - declares `frasermolyneux-copilot` as a local stdio MCP server pointing at `.github-copilot/mcp-server/dist/index.js` with `GH_COPILOT_CONTENT_ROOT=.github-copilot` and `tools: ["*"]`.
- **`.github/copilot-instructions.md`** - appends the canonical `## Org conventions via MCP (when available)` bootstrap snippet, byte-identical to the source-of-truth in `metadata.copilot-instructions.instructions.md` (sha256 `DDAC8AA449794730...`, 1094 chars).
- **`README.md`** - brief `## Local dev: MCP wire-up` section pointing at `.github-copilot/mcp-server/README.md` for full wire-up docs.

## Notes for reviewers

- **`AGENTS.md` intentionally untouched.** This repo does not have one yet. Per the rollout plan, AGENTS.md is owned by the `update-project-metadata` agent; a follow-up will seed it and then insert the same canonical snippet there.
- The existing `Checkout shared Copilot configuration` step was previously unpinned. Adding the `v0.1.0` ref pin is a deliberate tightening to align with the template - runner builds against the same MCP server every time now.
- Snippet integrity verified by sha256 of the appended text block (`DDAC8AA449794730F687EA61759C392D45C6C4E6C7A85C608EF365E15E748F6B`).