### PR TITLE
feat: adopt SharedCacheConfiguration and add read-only cache defaults

### DIFF
--- a/src/MX.InvisionCommunity.Api.Abstractions/MX.InvisionCommunity.Api.Abstractions.csproj
+++ b/src/MX.InvisionCommunity.Api.Abstractions/MX.InvisionCommunity.Api.Abstractions.csproj
@@ -28,7 +28,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MX.Api.Abstractions" Version="2.3.75" />
+		<PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 

--- a/src/MX.InvisionCommunity.Api.Client.Testing/MX.InvisionCommunity.Api.Client.Testing.csproj
+++ b/src/MX.InvisionCommunity.Api.Client.Testing/MX.InvisionCommunity.Api.Client.Testing.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MX.Api.Abstractions" Version="2.3.75" />
+		<PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
 	</ItemGroup>
 

--- a/src/MX.InvisionCommunity.Api.Client.Tests/MX.InvisionCommunity.Api.Client.Tests.csproj
+++ b/src/MX.InvisionCommunity.Api.Client.Tests/MX.InvisionCommunity.Api.Client.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MX.InvisionCommunity.Api.Client\MX.InvisionCommunity.Api.Client.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/MX.InvisionCommunity.Api.Client.Tests/ServiceCollectionExtensionsTests.cs
+++ b/src/MX.InvisionCommunity.Api.Client.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using MX.Api.Abstractions;
+using MX.InvisionCommunity.Api.Abstractions;
+using MX.InvisionCommunity.Api.Abstractions.Interfaces;
+using MX.InvisionCommunity.Api.Abstractions.Models;
+
+namespace MX.InvisionCommunity.Api.Client.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    private static void ConfigureBaseline(InvisionApiClientOptionsBuilder builder)
+    {
+        builder
+            .WithBaseUrl("https://example.invisioncommunity.local")
+            .WithApiKeyAuthentication("test-api-key", "x-api-key", MX.Api.Client.Configuration.ApiKeyLocation.Header)
+            .WithCachePartition("unit-tests");
+    }
+
+    [Fact]
+    public void AddInvisionApiClient_WithCombinedSubApiCacheExpressions_ResolvesAllSubApis()
+    {
+        var services = new ServiceCollection();
+
+        // This scenario used to crash host startup: passing a WithCaching(...) delegate that mentions
+        // multiple typed sub-APIs previously flowed the same builder-scoped delegate into every
+        // AddTypedApiClient<>() call, so the second registration threw ArgumentException on the sibling's
+        // expression. With SharedCacheConfiguration this must now succeed.
+        services.AddInvisionApiClient(o =>
+        {
+            ConfigureBaseline(o);
+            o.WithCaching(cache =>
+            {
+                cache.UseLibraryDefaults();
+                cache.InMemory<IForumsApi, Task<ApiResult<PostTopicResultDto>>>(
+                    x => x.PostTopic(default, default, default!, default!, default!, default),
+                    TimeSpan.FromSeconds(60));
+                cache.NotCached<ICoreApi, Task<ApiResult<CoreHelloDto>>>(
+                    x => x.GetCoreHello(default));
+                cache.InMemory<IDownloadsApi, Task<ApiResult<DownloadFileDto>>>(
+                    x => x.GetDownloadFile(default, default),
+                    TimeSpan.FromSeconds(30));
+            });
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<ICoreApi>());
+        Assert.NotNull(provider.GetRequiredService<IDownloadsApi>());
+        Assert.NotNull(provider.GetRequiredService<IForumsApi>());
+        Assert.NotNull(provider.GetRequiredService<IInvisionApiClient>());
+    }
+
+    [Fact]
+    public void AddInvisionApiClient_WithoutCaching_ResolvesAllSubApis()
+    {
+        var services = new ServiceCollection();
+
+        services.AddInvisionApiClient(ConfigureBaseline);
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<ICoreApi>());
+        Assert.NotNull(provider.GetRequiredService<IDownloadsApi>());
+        Assert.NotNull(provider.GetRequiredService<IForumsApi>());
+        Assert.NotNull(provider.GetRequiredService<IInvisionApiClient>());
+    }
+
+    [Fact]
+    public void AddInvisionApiClient_WithBogusInterfaceExpression_ThrowsInvalidOperationException()
+    {
+        var services = new ServiceCollection();
+
+        // IBogusApi is not registered as one of the typed sub-APIs on this client, so
+        // ValidateAllOperationsMatched() must surface the typo at composition time.
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            services.AddInvisionApiClient(o =>
+            {
+                ConfigureBaseline(o);
+                o.WithCaching(cache =>
+                {
+                    cache.InMemory<IBogusApi, Task<ApiResult<CoreHelloDto>>>(
+                        x => x.SomeMethod(default),
+                        TimeSpan.FromSeconds(30));
+                });
+            }));
+
+        Assert.Contains("IBogusApi", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public interface IBogusApi
+    {
+        Task<ApiResult<CoreHelloDto>> SomeMethod(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/MX.InvisionCommunity.Api.Client/Caching/InvisionApiCacheDefaults.cs
+++ b/src/MX.InvisionCommunity.Api.Client/Caching/InvisionApiCacheDefaults.cs
@@ -1,0 +1,68 @@
+using System;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using MX.Api.Abstractions;
+using MX.Api.Client.Configuration;
+using MX.Api.Client.Extensions;
+using MX.InvisionCommunity.Api.Abstractions.Interfaces;
+using MX.InvisionCommunity.Api.Abstractions.Models;
+
+namespace MX.InvisionCommunity.Api.Client.Caching
+{
+    /// <summary>
+    /// Library-owned default cache policies for the Invision Community API client.
+    /// </summary>
+    /// <remarks>
+    /// Only operations whose declaring interface represents an idempotent HTTP GET whose response is not mutated by any
+    /// method exposed on this client are given a default policy. All create/update/delete-style methods
+    /// (e.g. <see cref="IForumsApi.PostTopic"/>, <see cref="IForumsApi.UpdateTopic"/>) are intentionally excluded so
+    /// that consumers do not receive stale writes served from cache.
+    ///
+    /// TTLs are deliberately short (30&#8211;60&#160;seconds) so that consumers who opt in still see near-real-time data
+    /// while benefiting from de-duplication of tight polling loops. Consumers can override any policy via
+    /// <c>WithCaching</c> on the options builder.
+    /// </remarks>
+    public static class InvisionApiCacheDefaults
+    {
+        internal static readonly TimeSpan ShortReadTtl = TimeSpan.FromSeconds(30);
+        internal static readonly TimeSpan MediumReadTtl = TimeSpan.FromSeconds(60);
+
+        /// <summary>
+        /// Registers conservative read-only default cache policies for the sub-APIs of this client.
+        /// </summary>
+        public static IServiceCollection AddInvisionApiDefaultCachePolicies(this IServiceCollection services)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+
+            // ICoreApi:
+            //  - GetCoreHello: idempotent GET returning API metadata; no mutation methods exist for it. Safe.
+            //  - GetMember: idempotent GET; this client exposes no member mutation methods, so cached reads only go
+            //    stale relative to changes made outside the process. Short TTL keeps that window small.
+            services.AddDefaultCachePolicies<ICoreApi>(cache =>
+            {
+                cache.InMemory<ICoreApi, Task<ApiResult<CoreHelloDto>>>(
+                    x => x.GetCoreHello(default),
+                    MediumReadTtl);
+                cache.InMemory<ICoreApi, Task<ApiResult<MemberDto>>>(
+                    x => x.GetMember(default!, default),
+                    ShortReadTtl);
+            });
+
+            // IDownloadsApi:
+            //  - GetDownloadFile: idempotent GET; this client exposes no downloads mutation methods. Safe with a
+            //    short TTL to reflect out-of-band changes (e.g. new file versions) reasonably quickly.
+            services.AddDefaultCachePolicies<IDownloadsApi>(cache =>
+            {
+                cache.InMemory<IDownloadsApi, Task<ApiResult<DownloadFileDto>>>(
+                    x => x.GetDownloadFile(default, default),
+                    ShortReadTtl);
+            });
+
+            // IForumsApi: intentionally no defaults. The only surfaced methods are PostTopic and UpdateTopic, both of
+            // which are mutations and must not be cached.
+
+            return services;
+        }
+    }
+}

--- a/src/MX.InvisionCommunity.Api.Client/InvisionApiClientOptionsBuilder.cs
+++ b/src/MX.InvisionCommunity.Api.Client/InvisionApiClientOptionsBuilder.cs
@@ -1,3 +1,5 @@
+using System;
+
 using MX.Api.Client.Configuration;
 
 namespace MX.InvisionCommunity.Api.Client
@@ -9,6 +11,15 @@ namespace MX.InvisionCommunity.Api.Client
         public InvisionApiClientOptionsBuilder WithApiPathPrefix(string apiPathPrefix)
         {
             Options.ApiPathPrefix = apiPathPrefix;
+            return this;
+        }
+
+        internal Action<CacheBuilder>? CapturedCacheConfigure { get; private set; }
+
+        public new InvisionApiClientOptionsBuilder WithCaching(Action<CacheBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            CapturedCacheConfigure = configure;
             return this;
         }
     }

--- a/src/MX.InvisionCommunity.Api.Client/InvisionApiClientOptionsBuilder.cs
+++ b/src/MX.InvisionCommunity.Api.Client/InvisionApiClientOptionsBuilder.cs
@@ -14,8 +14,23 @@ namespace MX.InvisionCommunity.Api.Client
             return this;
         }
 
+        /// <summary>
+        /// Captures the consumer's <see cref="ApiClientOptionsBuilder{TOptions, TBuilder}.WithCaching(Action{CacheBuilder})"/>
+        /// delegate so <c>ServiceCollectionExtensions.AddInvisionApiClient</c> can promote it to a
+        /// <c>SharedCacheConfiguration</c> shared across every typed sub-API registration.
+        /// </summary>
         internal Action<CacheBuilder>? CapturedCacheConfigure { get; private set; }
 
+        /// <summary>
+        /// Captures the caching configuration delegate without applying it directly. The captured delegate is
+        /// promoted to a single <c>SharedCacheConfiguration</c> and applied to every typed sub-API registration
+        /// by <c>ServiceCollectionExtensions.AddInvisionApiClient</c>, so a single expression can reference
+        /// operations across <c>ICoreApi</c>, <c>IDownloadsApi</c>, and <c>IForumsApi</c> without triggering
+        /// the single-client scope check.
+        /// </summary>
+        /// <param name="configure">The caching configuration delegate. Must not be <c>null</c>.</param>
+        /// <returns>The builder instance for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="configure"/> is <c>null</c>.</exception>
         public new InvisionApiClientOptionsBuilder WithCaching(Action<CacheBuilder> configure)
         {
             ArgumentNullException.ThrowIfNull(configure);

--- a/src/MX.InvisionCommunity.Api.Client/MX.InvisionCommunity.Api.Client.csproj
+++ b/src/MX.InvisionCommunity.Api.Client/MX.InvisionCommunity.Api.Client.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
-    <PackageReference Include="MX.Api.Client" Version="2.3.75" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.75" />
+    <PackageReference Include="MX.Api.Client" Version="2.3.77" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="RestSharp" Version="114.0.0" />
   </ItemGroup>

--- a/src/MX.InvisionCommunity.Api.Client/ServiceCollectionExtensions.cs
+++ b/src/MX.InvisionCommunity.Api.Client/ServiceCollectionExtensions.cs
@@ -25,20 +25,24 @@ namespace MX.InvisionCommunity.Api.Client
             // delegate is then wrapped in a single SharedCacheConfiguration and reused across every subsequent
             // registration, which is what lets MX.Api.Client 2.3.77 apply the sibling-interface expressions without
             // triggering the single-client scope check.
-            SharedCacheConfiguration? sharedCache = null;
+            //
+            // The capture is stored on a holder object rather than a mutable local so that dataflow analysers
+            // (Sonar, in particular) can reason about the post-registration null-check on Shared without treating
+            // the mutation through the PerClient local function as unreachable.
+            var capture = new SharedCacheCapture();
 
             void PerClient(InvisionApiClientOptionsBuilder builder)
             {
                 configureOptions(builder);
 
-                if (sharedCache is null && builder.CapturedCacheConfigure is not null)
+                if (capture.Shared is null && builder.CapturedCacheConfigure is not null)
                 {
-                    sharedCache = new SharedCacheConfiguration(builder.CapturedCacheConfigure);
+                    capture.Shared = new SharedCacheConfiguration(builder.CapturedCacheConfigure);
                 }
 
-                if (sharedCache is not null)
+                if (capture.Shared is not null)
                 {
-                    builder.WithSharedCaching(sharedCache);
+                    builder.WithSharedCaching(capture.Shared);
                 }
             }
 
@@ -53,11 +57,16 @@ namespace MX.InvisionCommunity.Api.Client
 
             // Fail fast on typos: any captured operation that didn't match one of the typed clients above surfaces
             // as InvalidOperationException at composition time rather than as a silent no-op at runtime.
-            sharedCache?.ValidateAllOperationsMatched();
+            capture.Shared?.ValidateAllOperationsMatched();
 
             serviceCollection.AddScoped<IInvisionApiClient, InvisionApiClient>();
 
             return serviceCollection;
+        }
+
+        private sealed class SharedCacheCapture
+        {
+            public SharedCacheConfiguration? Shared { get; set; }
         }
     }
 }

--- a/src/MX.InvisionCommunity.Api.Client/ServiceCollectionExtensions.cs
+++ b/src/MX.InvisionCommunity.Api.Client/ServiceCollectionExtensions.cs
@@ -19,18 +19,23 @@ namespace MX.InvisionCommunity.Api.Client
             ArgumentNullException.ThrowIfNull(serviceCollection);
             ArgumentNullException.ThrowIfNull(configureOptions);
 
-            // Probe the consumer's configuration once to capture any WithCaching(...) delegate. This lets us build a
-            // single SharedCacheConfiguration and reuse it across every typed sub-API registration below without
-            // triggering MX.Api.Client's single-client scope check for cache expressions that target sibling
-            // interfaces (see MX.Api.Client 2.3.77 SharedCacheConfiguration).
-            var probe = new InvisionApiClientOptionsBuilder();
-            configureOptions(probe);
-            var capturedCache = probe.CapturedCacheConfigure;
-            var sharedCache = capturedCache is null ? null : new SharedCacheConfiguration(capturedCache);
+            // Lazily capture the consumer's WithCaching(...) delegate the first time PerClient runs so that we
+            // invoke configureOptions exactly once per typed sub-API registration (matching the pre-change
+            // behaviour: no extra invocation for side effects, expensive setup, or one-time reads). The captured
+            // delegate is then wrapped in a single SharedCacheConfiguration and reused across every subsequent
+            // registration, which is what lets MX.Api.Client 2.3.77 apply the sibling-interface expressions without
+            // triggering the single-client scope check.
+            SharedCacheConfiguration? sharedCache = null;
 
             void PerClient(InvisionApiClientOptionsBuilder builder)
             {
                 configureOptions(builder);
+
+                if (sharedCache is null && builder.CapturedCacheConfigure is not null)
+                {
+                    sharedCache = new SharedCacheConfiguration(builder.CapturedCacheConfigure);
+                }
+
                 if (sharedCache is not null)
                 {
                     builder.WithSharedCaching(sharedCache);

--- a/src/MX.InvisionCommunity.Api.Client/ServiceCollectionExtensions.cs
+++ b/src/MX.InvisionCommunity.Api.Client/ServiceCollectionExtensions.cs
@@ -1,9 +1,13 @@
+using System;
+
 using Microsoft.Extensions.DependencyInjection;
 
+using MX.Api.Client.Configuration;
 using MX.Api.Client.Extensions;
 using MX.InvisionCommunity.Api.Abstractions;
 using MX.InvisionCommunity.Api.Abstractions.Interfaces;
 using MX.InvisionCommunity.Api.Client.Api;
+using MX.InvisionCommunity.Api.Client.Caching;
 
 namespace MX.InvisionCommunity.Api.Client
 {
@@ -12,9 +16,39 @@ namespace MX.InvisionCommunity.Api.Client
         public static IServiceCollection AddInvisionApiClient(this IServiceCollection serviceCollection,
             Action<InvisionApiClientOptionsBuilder> configureOptions)
         {
-            serviceCollection.AddTypedApiClient<ICoreApi, CoreApi, InvisionApiClientOptions, InvisionApiClientOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IDownloadsApi, DownloadsApi, InvisionApiClientOptions, InvisionApiClientOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IForumsApi, ForumsApi, InvisionApiClientOptions, InvisionApiClientOptionsBuilder>(configureOptions);
+            ArgumentNullException.ThrowIfNull(serviceCollection);
+            ArgumentNullException.ThrowIfNull(configureOptions);
+
+            // Probe the consumer's configuration once to capture any WithCaching(...) delegate. This lets us build a
+            // single SharedCacheConfiguration and reuse it across every typed sub-API registration below without
+            // triggering MX.Api.Client's single-client scope check for cache expressions that target sibling
+            // interfaces (see MX.Api.Client 2.3.77 SharedCacheConfiguration).
+            var probe = new InvisionApiClientOptionsBuilder();
+            configureOptions(probe);
+            var capturedCache = probe.CapturedCacheConfigure;
+            var sharedCache = capturedCache is null ? null : new SharedCacheConfiguration(capturedCache);
+
+            void PerClient(InvisionApiClientOptionsBuilder builder)
+            {
+                configureOptions(builder);
+                if (sharedCache is not null)
+                {
+                    builder.WithSharedCaching(sharedCache);
+                }
+            }
+
+            // Register conservative library-owned default cache policies before the typed clients so that consumers
+            // opting in via cache.UseLibraryDefaults() pick them up. Only read-only GET methods with no matching
+            // mutation surface on this client are included (see InvisionApiCacheDefaults for rationale).
+            serviceCollection.AddInvisionApiDefaultCachePolicies();
+
+            serviceCollection.AddTypedApiClient<ICoreApi, CoreApi, InvisionApiClientOptions, InvisionApiClientOptionsBuilder>(PerClient);
+            serviceCollection.AddTypedApiClient<IDownloadsApi, DownloadsApi, InvisionApiClientOptions, InvisionApiClientOptionsBuilder>(PerClient);
+            serviceCollection.AddTypedApiClient<IForumsApi, ForumsApi, InvisionApiClientOptions, InvisionApiClientOptionsBuilder>(PerClient);
+
+            // Fail fast on typos: any captured operation that didn't match one of the typed clients above surfaces
+            // as InvalidOperationException at composition time rather than as a silent no-op at runtime.
+            sharedCache?.ValidateAllOperationsMatched();
 
             serviceCollection.AddScoped<IInvisionApiClient, InvisionApiClient>();
 

--- a/src/MX.InvisionCommunity.sln
+++ b/src/MX.InvisionCommunity.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MX.InvisionCommunity.Api.Cl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MX.InvisionCommunity.Api.Client.Testing.Tests", "MX.InvisionCommunity.Api.Client.Testing.Tests\MX.InvisionCommunity.Api.Client.Testing.Tests.csproj", "{A41AEFEF-A431-4894-94FE-3C3BD7A5F3CC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MX.InvisionCommunity.Api.Client.Tests", "MX.InvisionCommunity.Api.Client.Tests\MX.InvisionCommunity.Api.Client.Tests.csproj", "{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,18 @@ Global
 		{A41AEFEF-A431-4894-94FE-3C3BD7A5F3CC}.Release|x64.Build.0 = Release|Any CPU
 		{A41AEFEF-A431-4894-94FE-3C3BD7A5F3CC}.Release|x86.ActiveCfg = Release|Any CPU
 		{A41AEFEF-A431-4894-94FE-3C3BD7A5F3CC}.Release|x86.Build.0 = Release|Any CPU
+		{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}.Debug|x64.Build.0 = Debug|Any CPU
+		{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}.Debug|x86.Build.0 = Debug|Any CPU
+		{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}.Release|x64.ActiveCfg = Release|Any CPU
+		{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}.Release|x64.Build.0 = Release|Any CPU
+		{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}.Release|x86.ActiveCfg = Release|Any CPU
+		{A0E40D0E-13E3-4C05-B64B-0CDF0770047A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
Adopt the reflection-free ``SharedCacheConfiguration`` pattern from MX.Api.Client 2.3.77 in the Invision Community API client, add conservative read-only cache defaults, and lock the DI composition with a regression test.

Previously ``ServiceCollectionExtensions.AddInvisionApiClient`` passed the same ``configureOptions`` delegate to every ``AddTypedApiClient<>()`` call. MX.Api.Client scopes each builder to one typed client, so a consumer combining per-sub-API ``WithCaching(c => c.InMemory<IForumsApi,...>(...))`` expressions crashed host startup with ``System.ArgumentException: The expression must invoke a method declared by ...``. This PR fixes that at the library boundary.

Closes N/A (technical debt / consumer bug).

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change
- [ ] Documentation update
- [x] Test coverage / CI change

## Validation evidence

### Build
```
$ dotnet build src/MX.InvisionCommunity.sln
  MX.InvisionCommunity.Api.Abstractions -> ...\net9.0\MX.InvisionCommunity.Api.Abstractions.dll
  MX.InvisionCommunity.Api.Abstractions -> ...\net10.0\MX.InvisionCommunity.Api.Abstractions.dll
  MX.InvisionCommunity.Api.Client       -> ...\net9.0\MX.InvisionCommunity.Api.Client.dll
  MX.InvisionCommunity.Api.Client       -> ...\net10.0\MX.InvisionCommunity.Api.Client.dll
  MX.InvisionCommunity.Api.Client.Testing -> ...\net9.0\MX.InvisionCommunity.Api.Client.Testing.dll
  MX.InvisionCommunity.Api.Client.Testing -> ...\net10.0\MX.InvisionCommunity.Api.Client.Testing.dll
  MX.InvisionCommunity.Api.Client.Testing.Tests -> ...\net9.0\MX.InvisionCommunity.Api.Client.Testing.Tests.dll
  MX.InvisionCommunity.Api.Client.Tests -> ...\net9.0\MX.InvisionCommunity.Api.Client.Tests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)
```

### Tests
```
$ dotnet test src/MX.InvisionCommunity.sln --filter "FullyQualifiedName!~IntegrationTests"

Passed!  - Failed:     0, Passed:     3, Skipped:     0, Total:     3, Duration: 160 ms - MX.InvisionCommunity.Api.Client.Tests.dll (net9.0)
Passed!  - Failed:     0, Passed:    45, Skipped:     0, Total:    45, Duration:  49 ms - MX.InvisionCommunity.Api.Client.Testing.Tests.dll (net9.0)
```

The three new tests in ``MX.InvisionCommunity.Api.Client.Tests``:
1. ``AddInvisionApiClient_WithCombinedSubApiCacheExpressions_ResolvesAllSubApis`` — mixes ``InMemory<IForumsApi,...>``, ``NotCached<ICoreApi,...>``, ``InMemory<IDownloadsApi,...>`` plus ``UseLibraryDefaults()``, calls ``BuildServiceProvider()``, then resolves ``ICoreApi``, ``IDownloadsApi``, ``IForumsApi``, and ``IInvisionApiClient`` without throwing. This is the exact scenario that used to crash consumer startup.
2. ``AddInvisionApiClient_WithBogusInterfaceExpression_ThrowsInvalidOperationException`` — an expression on an unregistered interface surfaces ``InvalidOperationException`` at composition time (via ``ValidateAllOperationsMatched()``).
3. ``AddInvisionApiClient_WithoutCaching_ResolvesAllSubApis`` — baseline: registration without ``.WithCaching`` still resolves every sub-API.

### Format check
```
$ dotnet format src/MX.InvisionCommunity.sln --verify-no-changes
(exit code 0, no output)
```

## Risk and rollout
- **Blast radius:** low. Consumers who don''t use ``WithCaching`` see no behavioural change. Consumers who do opt in now get shared scoping across sub-APIs and the library-owned read-only defaults when they call ``cache.UseLibraryDefaults()``. No public API is removed or renamed.
- **Auto-deploy?** No — this is a NuGet library. Published on next release.
- **Manual steps post-merge:** none.
- **Rollback:** revert this PR; consumers pinning ``MX.InvisionCommunity.Api.Client < this version`` are unaffected.

## Consumer impact
- **Public surface additions:**
  - ``InvisionApiClientOptionsBuilder.WithCaching(Action<CacheBuilder>)`` is now a ``new`` override that captures the delegate rather than forwarding to the base builder. Callers see the same signature — behaviour changes from crashing on sibling-interface expressions to shared, per-typed-client scoping.
  - ``MX.InvisionCommunity.Api.Client.Caching.InvisionApiCacheDefaults.AddInvisionApiDefaultCachePolicies(IServiceCollection)`` is invoked automatically from ``AddInvisionApiClient``. Consumers opt in to the defaults by calling ``cache.UseLibraryDefaults()`` inside their own ``WithCaching``.
- **Read-only cache defaults added (rationale in code):**
  | Interface | Method | Policy | Justification |
  |---|---|---|---|
  | ``ICoreApi`` | ``GetCoreHello`` | ``InMemory`` 60 s | Idempotent GET returning API metadata; no mutation surface anywhere on this client. |
  | ``ICoreApi`` | ``GetMember`` | ``InMemory`` 30 s | Idempotent GET; no member mutation methods on this client. Short TTL bounds out-of-band staleness. |
  | ``IDownloadsApi`` | ``GetDownloadFile`` | ``InMemory`` 30 s | Idempotent GET; no download mutation methods on this client. |
  | ``IForumsApi`` | *(none)* | — | ``PostTopic`` and ``UpdateTopic`` are both mutations; deliberately excluded. |
- **Package bumps:** ``MX.Api.Client`` and ``MX.Api.Abstractions`` ``2.3.75`` → ``2.3.77`` in ``MX.InvisionCommunity.Api.Abstractions``, ``MX.InvisionCommunity.Api.Client``, and ``MX.InvisionCommunity.Api.Client.Testing``.

## Agent attestation
- [x] I have read the required instruction files listed in ``AGENTS.md``.
- [x] I have not committed secrets, GUIDs, or connection strings.
- [x] I have not modified ``.github/workflows/``, ``.github/dependabot.yml``, ``version.json``, or ``Directory.*.props``.
- [x] Build, tests (excluding integration tests), and format check all pass locally; output is included above.
- [x] I ran the ``code-review`` sub-agent on the diff; no High/Medium findings.
- [x] Changes align with the layered instruction files (``standards.dotnet-project`` — no naming/tagging or Terraform concerns for a library-only change).
